### PR TITLE
Fixed error in filter of search in home page

### DIFF
--- a/src/property/views.py
+++ b/src/property/views.py
@@ -9,12 +9,12 @@ def property_list(request):
     
     address_query  = request.GET.get('q')
     property_type = request.GET.get('property_type',None)
-    if address_query  and property_type:
+    if address_query is not None and property_type is not None:
         print(address_query)
         print(property_type)
         property_list =property_list.filter(
             Q(name__icontains=address_query) & 
-            Q(property_type__icontains=property_type[0])
+            Q(property_type__icontains=property_type)
         ).distinct()
 
     print(property_list)


### PR DESCRIPTION

Fixes #6 

1) Changed a line of code in property/views.py from:
```python
 if address_query  and property_type:
```
to:
```python
if address_query is not None and property_type is not None:
```
as the filter is not working in case of _given **property_type**_ and _empty **address_query**_. Which infact should return all the properties applying the filter of given property_type.

AND

2) Changed a line of code in property/views.py from:
```python
Q(property_type__icontains=property_type[0])
```
to:
```python
Q(property_type__icontains=property_type)
```
as **property_type[0] returns the 0th letter** of the param value. But we **need the whole string value** of property_type to filter the properties not only the starting letter.
            
            